### PR TITLE
特定のNodeまで展開する処理を追加

### DIFF
--- a/CITreeView.podspec
+++ b/CITreeView.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'CITreeView'
-  s.version          = '1.8.0'
+  s.version          = '2.0.0'
   s.summary          = 'CITreeView created to implement and maintain that wanted TreeView structures for IOS platforms easy way.'
 
   s.description      = <<-DESC
@@ -9,7 +9,8 @@ CITreeView created to implement and maintain that wanted TreeView structures for
 
   s.homepage         = 'https://github.com/cenksk/CITreeView'
   s.license          = { :type => 'MIT', :file => 'LICENSE' }
-  s.author           = { 'Cenk Işık' => 'isik.cnk@gmail.com' }
+  s.author           = { 'Cenk Işık' => 'isik.cnk@gmail.com',
+                        'takeguchi' => 'takeguchi@kiroru-inc.jp' }
   s.source           = { :git => 'https://github.com/kiroru/CITreeView.git', :tag => s.version.to_s }
 
   s.ios.deployment_target = '10.0'

--- a/CITreeView/CITreeView/CITreeViewClasses/CITreeView.swift
+++ b/CITreeView/CITreeView/CITreeViewClasses/CITreeView.swift
@@ -18,6 +18,7 @@ public protocol CITreeViewDataSource: NSObjectProtocol {
 
 @objc
 public protocol CITreeViewDelegate: NSObjectProtocol {
+    func treeViewDidReloadData(_ treeView: CITreeView, changeStat: Bool)
     func treeView(_ treeView: CITreeView, heightForRowAt indexPath: IndexPath, with treeViewNode: CITreeViewNode) -> CGFloat
     func treeView(_ treeView: CITreeView, didSelectRowAt treeViewNode: CITreeViewNode, at indexPath: IndexPath)
     func treeView(_ treeView: CITreeView, didDeselectRowAt treeViewNode: CITreeViewNode, at indexPath: IndexPath)
@@ -70,6 +71,7 @@ public class CITreeView: UITableView {
         mainDataArray = treeViewController.treeViewNodes
         
         super.reloadData()
+        treeViewDelegate?.treeViewDidReloadData(self, changeStat: true)
     }
 
     public func reloadDataWithoutChangingRowStates() {
@@ -88,6 +90,7 @@ public class CITreeView: UITableView {
             mainDataArray = treeViewController.treeViewNodes
         }
         super.reloadData()
+        treeViewDelegate?.treeViewDidReloadData(self, changeStat: false)
     }
     
     fileprivate func deleteRows() {

--- a/CITreeView/CITreeView/CITreeViewClasses/CITreeViewController.swift
+++ b/CITreeView/CITreeView/CITreeViewClasses/CITreeViewController.swift
@@ -9,7 +9,7 @@
 import Foundation
 
 public protocol CITreeViewControllerDelegate: NSObjectProtocol {
-    func getChildren(for treeViewNodeItem: AnyObject, at indexPath: IndexPath) -> [AnyObject]
+    func getChildren(for treeViewNodeItem: Any, at indexPath: IndexPath) -> [Any]
     func willExpandTreeViewNode(_ treeViewNode: CITreeViewNode, at indexPath: IndexPath)
     func willCollapseTreeViewNode(_ treeViewNode: CITreeViewNode, at indexPath: IndexPath)
 }
@@ -25,7 +25,7 @@ public class CITreeViewController: NSObject {
     }
     
     //MARK: Tree View Nodes Functions
-    func addTreeViewNode(with item: AnyObject) {
+    func addTreeViewNode(with item: Any) {
         let treeViewNode = CITreeViewNode(item: item)
         treeViewNodes.append(treeViewNode)
     }
@@ -41,7 +41,7 @@ public class CITreeViewController: NSObject {
         return treeViewNodes.firstIndex(of: treeViewNode)
     }
     
-    func insertTreeViewNode(parent parentTreeViewNode: CITreeViewNode, with item: AnyObject, to index: Int) {
+    func insertTreeViewNode(parent parentTreeViewNode: CITreeViewNode, with item: Any, to index: Int) {
         let treeViewNode = CITreeViewNode(item: item)
         treeViewNode.parentNode = parentTreeViewNode
         treeViewNodes.insert(treeViewNode, at: index)
@@ -200,9 +200,9 @@ public class CITreeViewController: NSObject {
         return IndexPath(row:0, section:0)
     }
 
-    func getIndexPathOfTreeViewNodeItem(item: AnyObject) -> IndexPath {
+    func getIndexPathOfTreeViewNodeItem(where predicate: (Any) -> Bool) -> IndexPath {
         for (index,node) in treeViewNodes.enumerated() {
-            if item === node.item {
+            if predicate(node.item) {
                 return IndexPath(row: index, section: 0)
             }
         }

--- a/CITreeView/CITreeView/CITreeViewClasses/CITreeViewController.swift
+++ b/CITreeView/CITreeView/CITreeViewClasses/CITreeViewController.swift
@@ -9,7 +9,7 @@
 import Foundation
 
 public protocol CITreeViewControllerDelegate: NSObjectProtocol {
-    func getChildren(for treeViewNodeItem: Any, at indexPath: IndexPath) -> [Any]
+    func getChildren(for treeViewNodeItem: AnyObject, at indexPath: IndexPath) -> [AnyObject]
     func willExpandTreeViewNode(_ treeViewNode: CITreeViewNode, at indexPath: IndexPath)
     func willCollapseTreeViewNode(_ treeViewNode: CITreeViewNode, at indexPath: IndexPath)
 }
@@ -25,7 +25,7 @@ public class CITreeViewController: NSObject {
     }
     
     //MARK: Tree View Nodes Functions
-    func addTreeViewNode(with item: Any) {
+    func addTreeViewNode(with item: AnyObject) {
         let treeViewNode = CITreeViewNode(item: item)
         treeViewNodes.append(treeViewNode)
     }
@@ -41,7 +41,7 @@ public class CITreeViewController: NSObject {
         return treeViewNodes.firstIndex(of: treeViewNode)
     }
     
-    func insertTreeViewNode(parent parentTreeViewNode: CITreeViewNode, with item: Any, to index: Int) {
+    func insertTreeViewNode(parent parentTreeViewNode: CITreeViewNode, with item: AnyObject, to index: Int) {
         let treeViewNode = CITreeViewNode(item: item)
         treeViewNode.parentNode = parentTreeViewNode
         treeViewNodes.insert(treeViewNode, at: index)
@@ -199,5 +199,13 @@ public class CITreeViewController: NSObject {
         }
         return IndexPath(row:0, section:0)
     }
-    
+
+    func getIndexPathOfTreeViewNodeItem(item: AnyObject) -> IndexPath {
+        for (index,node) in treeViewNodes.enumerated() {
+            if item === node.item {
+                return IndexPath(row: index, section: 0)
+            }
+        }
+        return IndexPath(row:0, section:0)
+    }
 }

--- a/CITreeView/CITreeView/CITreeViewClasses/CITreeViewNode.swift
+++ b/CITreeView/CITreeView/CITreeViewClasses/CITreeViewNode.swift
@@ -12,9 +12,9 @@ public final class CITreeViewNode: NSObject {
     public var parentNode: CITreeViewNode?
     public var expand: Bool = false
     public var level: Int = 0
-    public var item: Any
+    public var item: AnyObject
     
-    init(item: Any) {
+    init(item: AnyObject) {
         self.item = item
     }
 }

--- a/CITreeView/CITreeView/CITreeViewClasses/CITreeViewNode.swift
+++ b/CITreeView/CITreeView/CITreeViewClasses/CITreeViewNode.swift
@@ -12,9 +12,9 @@ public final class CITreeViewNode: NSObject {
     public var parentNode: CITreeViewNode?
     public var expand: Bool = false
     public var level: Int = 0
-    public var item: AnyObject
+    public var item: Any
     
-    init(item: AnyObject) {
+    init(item: Any) {
         self.item = item
     }
 }

--- a/CITreeView/CITreeView/Controllers/ViewController.swift
+++ b/CITreeView/CITreeView/Controllers/ViewController.swift
@@ -26,7 +26,14 @@ class ViewController: UIViewController {
     }
     
     @IBAction func reloadBarButtonAction(_ sender: UIBarButtonItem) {
-        sampleTreeView.expandAllRows()
+        let expandSample = data[5].children[1].children[2]
+        print("expandSample:\(expandSample.name)")
+        sampleTreeView.expandRowForNodeItem(expandSample, itemMatcher: {
+            guard let lhs = $0 as? CITreeViewData,
+                  let rhs = $1 as? CITreeViewData else { return false }
+            return lhs === rhs
+        })
+//        sampleTreeView.expandAllRows()
     }
     @IBAction func collapseAllRowsBarButtonAction(_ sender: UIBarButtonItem) {
         sampleTreeView.collapseAllRows()
@@ -37,9 +44,13 @@ class ViewController: UIViewController {
 extension ViewController : CITreeViewDelegate {
     func treeViewDidReloadData(_ treeView: CITreeView, changeStat: Bool) {
         if !initialized {
-            let expandSample = data[5].children[1].children[2].children[2]
+            let expandSample = data[5].children[1].children[2]
             print("expandSample:\(expandSample.name)")
-            sampleTreeView.expandRowRecursive(for: expandSample)
+            sampleTreeView.expandRowForNodeItem(expandSample, itemMatcher: {
+                guard let lhs = $0 as? CITreeViewData,
+                      let rhs = $1 as? CITreeViewData else { return false }
+                return lhs === rhs
+            })
             initialized = true
         }
     }
@@ -76,21 +87,21 @@ extension ViewController : CITreeViewDelegate {
 }
 
 extension ViewController : CITreeViewDataSource {
-    func treeViewAncestors(for treeViewNodeItem: AnyObject) -> [AnyObject] {
+    func treeViewAncestors(for treeViewNodeItem: Any) -> [Any] {
         guard let item = treeViewNodeItem as? CITreeViewData else { return [] }
         let ancestors = data.getAncestorsArray(of: item)
         print("ancestors:\(ancestors.map { $0.name })")
         return ancestors
     }
 
-    func treeViewSelectedNodeChildren(for treeViewNodeItem: AnyObject) -> [AnyObject] {
+    func treeViewSelectedNodeChildren(for treeViewNodeItem: Any) -> [Any] {
         if let dataObj = treeViewNodeItem as? CITreeViewData {
             return dataObj.children
         }
         return []
     }
     
-    func treeViewDataArray() -> [AnyObject] {
+    func treeViewDataArray() -> [Any] {
         return data
     }
     

--- a/CITreeView/CITreeView/Controllers/ViewController.swift
+++ b/CITreeView/CITreeView/Controllers/ViewController.swift
@@ -12,6 +12,7 @@ class ViewController: UIViewController {
     
     var data : [CITreeViewData] = []
     //var treeView:CITreeView!
+    var initialized = false
     
     let treeViewCellIdentifier = "TreeViewCellIdentifier"
     let treeViewCellNibName = "CITreeViewCell"
@@ -25,11 +26,7 @@ class ViewController: UIViewController {
     }
     
     @IBAction func reloadBarButtonAction(_ sender: UIBarButtonItem) {
-        let expandSample = data[5].children[1].children[2].children[2]
-        print("expandSample:\(expandSample.name)")
-        sampleTreeView.expandRowRecursive(for: expandSample)
-
-//        sampleTreeView.expandAllRows()
+        sampleTreeView.expandAllRows()
     }
     @IBAction func collapseAllRowsBarButtonAction(_ sender: UIBarButtonItem) {
         sampleTreeView.collapseAllRows()
@@ -38,6 +35,15 @@ class ViewController: UIViewController {
 }
 
 extension ViewController : CITreeViewDelegate {
+    func treeViewDidReloadData(_ treeView: CITreeView, changeStat: Bool) {
+        if !initialized {
+            let expandSample = data[5].children[1].children[2].children[2]
+            print("expandSample:\(expandSample.name)")
+            sampleTreeView.expandRowRecursive(for: expandSample)
+            initialized = true
+        }
+    }
+
     func treeViewNode(_ treeViewNode: CITreeViewNode, willExpandAt indexPath: IndexPath) {
         
     }

--- a/CITreeView/CITreeView/Controllers/ViewController.swift
+++ b/CITreeView/CITreeView/Controllers/ViewController.swift
@@ -25,7 +25,11 @@ class ViewController: UIViewController {
     }
     
     @IBAction func reloadBarButtonAction(_ sender: UIBarButtonItem) {
-        sampleTreeView.expandAllRows()
+        let expandSample = data[5].children[1].children[2].children[2]
+        print("expandSample:\(expandSample.name)")
+        sampleTreeView.expandRowRecursive(for: expandSample)
+
+//        sampleTreeView.expandAllRows()
     }
     @IBAction func collapseAllRowsBarButtonAction(_ sender: UIBarButtonItem) {
         sampleTreeView.collapseAllRows()
@@ -66,15 +70,21 @@ extension ViewController : CITreeViewDelegate {
 }
 
 extension ViewController : CITreeViewDataSource {
+    func treeViewAncestors(for treeViewNodeItem: AnyObject) -> [AnyObject] {
+        guard let item = treeViewNodeItem as? CITreeViewData else { return [] }
+        let ancestors = data.getAncestorsArray(of: item)
+        print("ancestors:\(ancestors.map { $0.name })")
+        return ancestors
+    }
 
-    func treeViewSelectedNodeChildren(for treeViewNodeItem: Any) -> [Any] {
+    func treeViewSelectedNodeChildren(for treeViewNodeItem: AnyObject) -> [AnyObject] {
         if let dataObj = treeViewNodeItem as? CITreeViewData {
             return dataObj.children
         }
         return []
     }
     
-    func treeViewDataArray() -> [Any] {
+    func treeViewDataArray() -> [AnyObject] {
         return data
     }
     
@@ -89,5 +99,30 @@ extension ViewController : CITreeViewDataSource {
 
 }
 
+private extension Array where Element == CITreeViewData {
+    func getAncestorsArray(of data: CITreeViewData) -> [CITreeViewData] {
+        var searchArray: [CITreeViewData] = []
+        for child in self {
+            if child.searchRecursive(of: data, with: &searchArray) {
+                break
+            }
+        }
+        return searchArray
+    }
+}
 
-
+private extension CITreeViewData {
+    func searchRecursive(of data: CITreeViewData, with matched: inout [CITreeViewData]) -> Bool {
+        if self === data {
+            matched.insert(self, at: 0)
+            return true
+        }
+        for child in children {
+            if child.searchRecursive(of: data, with: &matched) {
+                matched.insert(self, at: 0)
+                return true
+            }
+        }
+        return false
+    }
+}

--- a/CITreeView/CITreeView/Models/CITreeViewData.swift
+++ b/CITreeView/CITreeView/Models/CITreeViewData.swift
@@ -80,8 +80,54 @@ extension CITreeViewData {
         let child55 = CITreeViewData(name: "Bugatti")
         let parent5 = CITreeViewData(name: "Sports Car",children:[child51,child52,child53,child54,child55])
 
+        let child6111 = CITreeViewData(name: "111")
+        let child6112 = CITreeViewData(name: "112")
+        let child6113 = CITreeViewData(name: "113")
+        let child6121 = CITreeViewData(name: "121")
+        let child6122 = CITreeViewData(name: "122")
+        let child6123 = CITreeViewData(name: "123")
+        let child6131 = CITreeViewData(name: "131")
+        let child6132 = CITreeViewData(name: "132")
+        let child6133 = CITreeViewData(name: "133")
+
+        let child6211 = CITreeViewData(name: "211")
+        let child6212 = CITreeViewData(name: "212")
+        let child6213 = CITreeViewData(name: "213")
+        let child6221 = CITreeViewData(name: "221")
+        let child6222 = CITreeViewData(name: "222")
+        let child6223 = CITreeViewData(name: "223")
+        let child6231 = CITreeViewData(name: "231")
+        let child6232 = CITreeViewData(name: "232")
+        let child6233 = CITreeViewData(name: "233")
+
+        let child6311 = CITreeViewData(name: "311")
+        let child6312 = CITreeViewData(name: "312")
+        let child6313 = CITreeViewData(name: "313")
+        let child6321 = CITreeViewData(name: "321")
+        let child6322 = CITreeViewData(name: "322")
+        let child6323 = CITreeViewData(name: "323")
+        let child6331 = CITreeViewData(name: "331")
+        let child6332 = CITreeViewData(name: "332")
+        let child6333 = CITreeViewData(name: "333")
+
+        let child6110 = CITreeViewData(name: "110", children: [child6111, child6112, child6113])
+        let child6120 = CITreeViewData(name: "120", children: [child6121, child6122, child6123])
+        let child6130 = CITreeViewData(name: "130", children: [child6131, child6132, child6133])
+
+        let child6210 = CITreeViewData(name: "210", children: [child6211, child6212, child6213])
+        let child6220 = CITreeViewData(name: "220", children: [child6221, child6222, child6223])
+        let child6230 = CITreeViewData(name: "230", children: [child6231, child6232, child6233])
+
+        let child6310 = CITreeViewData(name: "310", children: [child6311, child6312, child6313])
+        let child6320 = CITreeViewData(name: "320", children: [child6321, child6322, child6323])
+        let child6330 = CITreeViewData(name: "330", children: [child6331, child6332, child6333])
         
-        return [parent5,parent2,parent1,parent3,parent4]
+        let child6100 = CITreeViewData(name: "100", children: [child6110, child6120, child6130])
+        let child6200 = CITreeViewData(name: "200", children: [child6210, child6220, child6230])
+        let child6300 = CITreeViewData(name: "300", children: [child6310, child6320, child6330])
+        let parent6 = CITreeViewData(name: "Deep Tree", children: [child6100, child6200, child6300])
+        
+        return [parent5,parent2,parent1,parent3,parent4,parent6]
     }
     
     

--- a/CITreeViewClasses/CITreeViewController.swift
+++ b/CITreeViewClasses/CITreeViewController.swift
@@ -199,5 +199,13 @@ public class CITreeViewController: NSObject {
         }
         return IndexPath(row:0, section:0)
     }
-    
+
+    func getIndexPathOfTreeViewNodeItem(where predicate: (Any) -> Bool) -> IndexPath {
+        for (index,node) in treeViewNodes.enumerated() {
+            if predicate(node.item) {
+                return IndexPath(row: index, section: 0)
+            }
+        }
+        return IndexPath(row:0, section:0)
+    }
 }


### PR DESCRIPTION
下記のAPIを変更しています

- CITreeViewDataSource
  - 追加 `func treeViewAncestors(for treeViewNodeItem: Any) -> [Any]`
- CITreeViewDelegate
  - 追加 `func treeViewDidReloadData(_ treeView: CITreeView, changeStat: Bool)`
- CITreeView
  - 追加 `func expandRowForNodeItem(_ targetItem: Any, expandTarget: Bool = false, itemMatcher: (Any, Any) -> Bool)`